### PR TITLE
Fix/Update: Multiple updates to the core fundamentals of ServerHub

### DIFF
--- a/dist/lib/core/controller/response.d.ts
+++ b/dist/lib/core/controller/response.d.ts
@@ -11,7 +11,7 @@ declare class SHResponse {
     statusCode: number;
     getHeaderNames(): Array<string>;
     hasHeader(name: string): boolean;
-    getContent(encoding?: string): String;
+    getContent(): String;
     getHeader(name: string): any;
     getHeaders(): Object;
     setHeader(prop: string, value: any): void;

--- a/dist/lib/core/controller/response.js
+++ b/dist/lib/core/controller/response.js
@@ -48,6 +48,7 @@ class SHResponse {
     setHeader(prop, value) {
         if (this._HeaderSent)
             throw new Error('Header already sent');
+        prop = prop.toLowerCase();
         if (ValidHeaders.indexOf(prop) !== -1) {
             this._Headers[prop] = value;
         }
@@ -95,6 +96,7 @@ class SHResponse {
         this._WriteHeadCalled = true;
         if (header)
             Object.keys(header).forEach(headerKey => {
+                headerKey = headerKey.toLowerCase();
                 if (ValidHeaders.indexOf(headerKey) !== -1) {
                     this._Headers[headerKey] = header[headerKey];
                 }
@@ -176,5 +178,5 @@ const ValidHeaders = [
     'X-DNS-Prefetch-Control',
     'X-Frame-Options',
     'X-XSS-Protectio'
-];
+].map(e => e.toLowerCase());
 const ValidStatusCode = [100, 101, 200, 201, 202, 203, 204, 205, 206, 300, 301, 302, 303, 304, 307, 308, 400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 511];

--- a/dist/lib/core/controller/response.js
+++ b/dist/lib/core/controller/response.js
@@ -33,8 +33,8 @@ class SHResponse {
     hasHeader(name) {
         return this._Headers.hasOwnProperty(name);
     }
-    getContent(encoding = 'utf8') {
-        return this._Content ? this._Content.toString(encoding) : void 0;
+    getContent() {
+        return this._Content ? this._Content : void 0;
     }
     getHeader(name) {
         if (this._HeaderSent)

--- a/dist/lib/core/core.js
+++ b/dist/lib/core/core.js
@@ -109,6 +109,7 @@ function RoutePath(path, request, res) {
 exports.RoutePath = RoutePath;
 function NoRoute(path, req, res) {
     let variables = global['EnvironmentVariables'];
+    path = path.match(/^([^?]*)/)[1];
     if (path === '/') {
         let hasmatch = false;
         variables.DefaultPages.forEach(ele => {

--- a/dist/lib/proxy/port-proxy.d.ts
+++ b/dist/lib/proxy/port-proxy.d.ts
@@ -1,8 +1,8 @@
 import { TLSConfiguration } from "../core/global";
 export interface IRedirectEntry {
     Hostname: string;
-    RemoteHostname: string;
-    RemotePort: number;
+    ForwardHostname: string;
+    ForwardPort: number;
 }
 export interface IRedirectTable extends Array<IRedirectEntry> {
 }

--- a/dist/lib/proxy/port-proxy.js
+++ b/dist/lib/proxy/port-proxy.js
@@ -26,8 +26,8 @@ function QueryDomain(str, col) {
     col.forEach(ent => {
         if (host.endsWith(ent.Hostname))
             entry = {
-                RemoteHostname: ent.RemoteHostname,
-                RemotePort: ent.RemotePort,
+                ForwardHostname: ent.ForwardHostname,
+                ForwardPort: ent.ForwardPort,
                 Hostname: ent.Hostname
             };
     });
@@ -54,11 +54,10 @@ const connectionListener = (req, res) => __awaiter(this, void 0, void 0, functio
                 followAllRedirects: true,
                 followRedirect: true
             };
-            options.headers.referer = GetHostString(!!TLS, entry.RemoteHostname, entry.RemotePort);
-            options.headers.host = entry.RemoteHostname + ':' + entry.RemotePort;
-            options.host = entry.RemoteHostname + ':' + entry.RemotePort;
-            console.log(options.headers);
-            let r = request(GetHostString(!!TLS, entry.RemoteHostname, entry.RemotePort), options);
+            options.headers.referer = GetHostString(!!TLS, entry.ForwardHostname, entry.ForwardPort);
+            options.headers.host = entry.ForwardHostname + ':' + entry.ForwardPort;
+            options.host = entry.ForwardHostname + ':' + entry.ForwardPort;
+            let r = request(GetHostString(!!TLS, entry.ForwardHostname, entry.ForwardPort), options);
             r.on('response', (rs) => {
                 res.writeHead(rs.statusCode, rs.headers);
             });
@@ -93,7 +92,7 @@ function default_1(table, proxy_port = 8080, https) {
     PROXY_COUNT++;
     if (table) {
         table.forEach(ent => {
-            if ((net_1.isIPv4(ent.Hostname) || IsDomain(ent.Hostname)) && ent.RemotePort < 65536 && ent.RemotePort > 0) {
+            if ((net_1.isIPv4(ent.Hostname) || IsDomain(ent.Hostname)) && ent.ForwardPort < 65536 && ent.ForwardPort > 0) {
                 filteredTable.push(ent);
             }
         });

--- a/dist/lib/proxy/port-proxy.js
+++ b/dist/lib/proxy/port-proxy.js
@@ -105,7 +105,8 @@ function default_1(table, proxy_port = 8080, https) {
             server = https_1.createServer({
                 key: https.Key,
                 cert: https.Cert,
-                ca: https.CA
+                ca: https.CA || '',
+                passphrase: https.Passphrase || ''
             }, connectionListener);
         }
         server.on('listening', () => {

--- a/lib/core/controller/response.ts
+++ b/lib/core/controller/response.ts
@@ -48,7 +48,7 @@ class SHResponse {
     }
 
     public getContent(): String {
-        return this._Content ? this._Content: void 0;
+        return this._Content ? this._Content : void 0;
     }
 
     public getHeader(name: string): any {
@@ -64,6 +64,7 @@ class SHResponse {
     public setHeader(prop: string, value: any) {
         if (this._HeaderSent)
             throw new Error('Header already sent');
+        prop = prop.toLowerCase();
         if (ValidHeaders.indexOf(prop) !== -1) {
             this._Headers[prop] = value;
         }
@@ -111,6 +112,7 @@ class SHResponse {
         this._WriteHeadCalled = true;
         if (header)
             Object.keys(header).forEach(headerKey => {
+                headerKey = headerKey.toLowerCase();
                 if (ValidHeaders.indexOf(headerKey) !== -1) {
                     this._Headers[headerKey] = header[headerKey];
                 }
@@ -192,7 +194,7 @@ const ValidHeaders = [
     'X-DNS-Prefetch-Control',
     'X-Frame-Options',
     'X-XSS-Protectio'
-];
+].map(e => e.toLowerCase());
 
 const ValidStatusCode = [100, 101, 200, 201, 202, 203, 204, 205, 206, 300, 301, 302, 303, 304, 307, 308, 400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 511];
 

--- a/lib/core/controller/response.ts
+++ b/lib/core/controller/response.ts
@@ -47,8 +47,8 @@ class SHResponse {
         return this._Headers.hasOwnProperty(name);
     }
 
-    public getContent(encoding = 'utf8'): String {
-        return this._Content ? this._Content.toString(encoding) : void 0;
+    public getContent(): String {
+        return this._Content ? this._Content: void 0;
     }
 
     public getHeader(name: string): any {

--- a/lib/core/core.ts
+++ b/lib/core/core.ts
@@ -145,7 +145,7 @@ export function RoutePath (path: string, request: IncomingMessage, res: ServerRe
 
 function NoRoute (path: string, req: IncomingMessage, res: ServerResponse): void {
     let variables = global['EnvironmentVariables'] as GlobalEnvironmentVariables;
-
+    path = path.match(/^([^?]*)/)[1];
     if (path === '/') {
         let hasmatch = false;
         variables.DefaultPages.forEach(ele => {

--- a/lib/proxy/port-proxy.ts
+++ b/lib/proxy/port-proxy.ts
@@ -17,8 +17,8 @@ import * as colors from 'colors';
 
 export interface IRedirectEntry {
     Hostname: string;
-    RemoteHostname: string;
-    RemotePort: number;
+    ForwardHostname: string;
+    ForwardPort: number;
 }
 
 export interface IRedirectTable extends Array<IRedirectEntry> { };
@@ -43,8 +43,8 @@ function QueryDomain (str: string, col: IRedirectTable): IRedirectEntry {
     col.forEach(ent => {
         if (host.endsWith(ent.Hostname))
             entry = {
-                RemoteHostname: ent.RemoteHostname,
-                RemotePort: ent.RemotePort,
+                ForwardHostname: ent.ForwardHostname,
+                ForwardPort: ent.ForwardPort,
                 Hostname: ent.Hostname
             } as IRedirectEntry;
     });
@@ -85,11 +85,11 @@ const connectionListener = async (req: IncomingMessage, res: ServerResponse) => 
                 followRedirect: true
             } as request.CoreOptions;
 
-            options.headers.referer = GetHostString(!!TLS, entry.RemoteHostname, entry.RemotePort);
-            options.headers.host = entry.RemoteHostname + ':' + entry.RemotePort;
-            options.host = entry.RemoteHostname + ':' + entry.RemotePort;
-            console.log(options.headers);
-            let r = request(GetHostString(!!TLS, entry.RemoteHostname, entry.RemotePort), options);
+            options.headers.referer = GetHostString(!!TLS, entry.ForwardHostname, entry.ForwardPort);
+            options.headers.host = entry.ForwardHostname + ':' + entry.ForwardPort;
+            options.host = entry.ForwardHostname + ':' + entry.ForwardPort;
+            
+            let r = request(GetHostString(!!TLS, entry.ForwardHostname, entry.ForwardPort), options);
             r.on('response', (rs) => {
                 res.writeHead(rs.statusCode, rs.headers);
             });
@@ -132,7 +132,7 @@ export default function (table: IRedirectTable, proxy_port = 8080, https?: TLSCo
     if (table) {
         // validation
         table.forEach(ent => {
-            if ((IsIPv4(ent.Hostname) || IsDomain(ent.Hostname)) && ent.RemotePort < 65536 && ent.RemotePort > 0) {
+            if ((IsIPv4(ent.Hostname) || IsDomain(ent.Hostname)) && ent.ForwardPort < 65536 && ent.ForwardPort > 0) {
                 filteredTable.push(ent);
             }
         });

--- a/lib/proxy/port-proxy.ts
+++ b/lib/proxy/port-proxy.ts
@@ -88,7 +88,7 @@ const connectionListener = async (req: IncomingMessage, res: ServerResponse) => 
             options.headers.referer = GetHostString(!!TLS, entry.ForwardHostname, entry.ForwardPort);
             options.headers.host = entry.ForwardHostname + ':' + entry.ForwardPort;
             options.host = entry.ForwardHostname + ':' + entry.ForwardPort;
-            
+
             let r = request(GetHostString(!!TLS, entry.ForwardHostname, entry.ForwardPort), options);
             r.on('response', (rs) => {
                 res.writeHead(rs.statusCode, rs.headers);
@@ -144,7 +144,8 @@ export default function (table: IRedirectTable, proxy_port = 8080, https?: TLSCo
             server = screateServer({
                 key: https.Key,
                 cert: https.Cert,
-                ca: https.CA
+                ca: https.CA || '',
+                passphrase: https.Passphrase || ''
             }, connectionListener);
         }
         server.on('listening', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1030,24 +1030,6 @@
         "which": "^1.2.9"
       }
     },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "requires": {
-        "boom": "5.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        }
-      }
-    },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -3148,6 +3130,26 @@
         "cryptiles": "3.x.x",
         "hoek": "4.x.x",
         "sntp": "2.x.x"
+      },
+      "dependencies": {
+        "cryptiles": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.4.tgz",
+          "integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
+          "requires": {
+            "boom": "5.x.x"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "requires": {
+                "hoek": "4.x.x"
+              }
+            }
+          }
+        }
       }
     },
     "he": {


### PR DESCRIPTION
**Is this pull request resolving an existing issue?**

No

**Is this pull request adding new features?**

1. Type converting issues
  When the original data is a binary file, the old functions tried to call `toString()` method on chunk (Buffer object) and pass it to `write()` method on ServerResponse instances. This may cause a mis-calculation of data loaded and the client cannot parse the response data correctly.
2. Header name too strict
  Old version of ServerHub only support setting HTTP header names like "Content-Type", but not everyone can remember that. So this merge contains update to that function that auto convert to lower-cases before actual comparison.

**Who do you want to review the request?**

@DongXYZ .

**Finally, please talk a little more about the changes that you made:**
